### PR TITLE
Mod nostr keys

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/siamdev/zappos/keys/NostrKeys.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/siamdev/zappos/keys/NostrKeys.android.kt
@@ -1,19 +1,24 @@
 package org.siamdev.zappos.keys
 
 import rust.nostr.sdk.Keys
+import rust.nostr.sdk.Nip44Version
 import rust.nostr.sdk.PublicKey
 import rust.nostr.sdk.SecretKey
 import rust.nostr.sdk.generateSharedKey
+import rust.nostr.sdk.nip04Decrypt
+import rust.nostr.sdk.nip44Decrypt
+import rust.nostr.sdk.nip44Encrypt
+import rust.nostr.sdk.nip04Encrypt
 
+
+actual enum class NIP44VERSION(internal val version: Nip44Version) {
+    V2(Nip44Version.V2)
+}
 @OptIn(ExperimentalStdlibApi::class)
 actual class NostrKeys private constructor(private val keys: Keys) {
     actual companion object {
         actual fun generate(): NostrKeys = NostrKeys(Keys.generate())
         actual fun parse(secretKey: String): NostrKeys = NostrKeys(Keys.parse(secretKey))
-        /*actual fun getSharedKey(secretKey: NostrSecretKey, publicKey: NostrPublicKey): ByteArray {
-            return generateSharedKey(secretKey.sk, publicKey.pk)
-        }*/
-
         actual fun getSharedKey(secretKey: NostrSecretKey, publicKey: NostrPublicKey): NostrKeys {
             val sharedKeyBytes = generateSharedKey(secretKey.sk, publicKey.pk)
             val sharedSecretKey = SecretKey.fromBytes(sharedKeyBytes)
@@ -21,6 +26,29 @@ actual class NostrKeys private constructor(private val keys: Keys) {
             return NostrKeys(sharedKeys)
         }
 
+        actual fun NIP04Encrypt(secretKey: NostrSecretKey, publicKey: NostrPublicKey, content: String): String {
+            return nip04Encrypt(secretKey.sk, publicKey.pk, content)
+        }
+        actual fun NIP04Decrypt(secretKey: NostrSecretKey, publicKey: NostrPublicKey, content: String): String {
+            return nip04Decrypt(secretKey.sk, publicKey.pk, content)
+        }
+
+        actual fun NIP44Encrypt(
+            secretKey: NostrSecretKey,
+            publicKey: NostrPublicKey,
+            content: String,
+            version: NIP44VERSION
+        ): String {
+            return nip44Encrypt(secretKey.sk, publicKey.pk, content, version.version)
+        }
+
+        actual fun NIP44Decrypt(
+            secretKey: NostrSecretKey,
+            publicKey: NostrPublicKey,
+            content: String
+        ): String {
+            return nip44Decrypt(secretKey.sk, publicKey.pk, content)
+        }
 
     }
 
@@ -45,3 +73,4 @@ actual class NostrSecretKey internal constructor(internal val sk: SecretKey) {
     actual fun toHex(): String = sk.toHex()
     actual fun toBech32(): String = sk.toBech32()
 }
+

--- a/composeApp/src/androidMain/kotlin/org/siamdev/zappos/keys/NostrKeys.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/siamdev/zappos/keys/NostrKeys.android.kt
@@ -3,13 +3,25 @@ package org.siamdev.zappos.keys
 import rust.nostr.sdk.Keys
 import rust.nostr.sdk.PublicKey
 import rust.nostr.sdk.SecretKey
+import rust.nostr.sdk.generateSharedKey
 
-
-
+@OptIn(ExperimentalStdlibApi::class)
 actual class NostrKeys private constructor(private val keys: Keys) {
     actual companion object {
         actual fun generate(): NostrKeys = NostrKeys(Keys.generate())
         actual fun parse(secretKey: String): NostrKeys = NostrKeys(Keys.parse(secretKey))
+        /*actual fun getSharedKey(secretKey: NostrSecretKey, publicKey: NostrPublicKey): ByteArray {
+            return generateSharedKey(secretKey.sk, publicKey.pk)
+        }*/
+
+        actual fun getSharedKey(secretKey: NostrSecretKey, publicKey: NostrPublicKey): NostrKeys {
+            val sharedKeyBytes = generateSharedKey(secretKey.sk, publicKey.pk)
+            val sharedSecretKey = SecretKey.fromBytes(sharedKeyBytes)
+            val sharedKeys = Keys.parse(sharedSecretKey.toHex())
+            return NostrKeys(sharedKeys)
+        }
+
+
     }
 
     actual fun secretKey(): NostrSecretKey = NostrSecretKey(keys.secretKey())
@@ -17,13 +29,19 @@ actual class NostrKeys private constructor(private val keys: Keys) {
     actual fun sign(msg: String): String = keys.signSchnorr(msg.hexToByteArray())
 }
 
-actual class NostrPublicKey internal constructor(private val pk: PublicKey) {
+actual class NostrPublicKey internal constructor(internal val pk: PublicKey) {
     actual fun toHex(): String = pk.toHex()
     actual fun toBech32(): String = pk.toBech32()
     actual fun toNostrUri(): String = pk.toNostrUri()
 }
 
-actual class NostrSecretKey internal constructor(private val sk: SecretKey) {
+actual class NostrSecretKey internal constructor(internal val sk: SecretKey) {
+    actual companion object {
+        actual fun fromBytes(bytes: ByteArray): NostrSecretKey {
+            val secretKey = SecretKey.fromBytes(bytes)
+            return NostrSecretKey(secretKey)
+        }
+    }
     actual fun toHex(): String = sk.toHex()
     actual fun toBech32(): String = sk.toBech32()
 }

--- a/composeApp/src/commonMain/kotlin/org/siamdev/zappos/keys/NostrKeys.kt
+++ b/composeApp/src/commonMain/kotlin/org/siamdev/zappos/keys/NostrKeys.kt
@@ -1,10 +1,21 @@
 package org.siamdev.zappos.keys
 
+
+expect enum class NIP44VERSION {
+    V2
+}
+
+
 expect class NostrKeys {
     companion object {
         fun generate(): NostrKeys
         fun parse(secretKey: String): NostrKeys
         fun getSharedKey(secretKey: NostrSecretKey, publicKey: NostrPublicKey): NostrKeys
+        fun NIP04Encrypt(secretKey: NostrSecretKey, publicKey: NostrPublicKey, content: String): String
+        fun NIP04Decrypt(secretKey: NostrSecretKey, publicKey: NostrPublicKey, content: String): String
+
+        fun NIP44Encrypt(secretKey: NostrSecretKey, publicKey: NostrPublicKey, content: String, version: NIP44VERSION): String
+        fun NIP44Decrypt(secretKey: NostrSecretKey, publicKey: NostrPublicKey, content: String): String
     }
 
     fun secretKey(): NostrSecretKey

--- a/composeApp/src/commonMain/kotlin/org/siamdev/zappos/keys/NostrKeys.kt
+++ b/composeApp/src/commonMain/kotlin/org/siamdev/zappos/keys/NostrKeys.kt
@@ -4,6 +4,7 @@ expect class NostrKeys {
     companion object {
         fun generate(): NostrKeys
         fun parse(secretKey: String): NostrKeys
+        fun getSharedKey(secretKey: NostrSecretKey, publicKey: NostrPublicKey): NostrKeys
     }
 
     fun secretKey(): NostrSecretKey
@@ -21,6 +22,9 @@ expect class NostrPublicKey {
 }
 
 expect class NostrSecretKey {
+    companion object {
+        fun fromBytes(bytes: ByteArray): NostrSecretKey
+    }
     fun toHex(): String
     fun toBech32(): String
 }

--- a/composeApp/src/commonMain/kotlin/org/siamdev/zappos/screen/NostrDemoScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/siamdev/zappos/screen/NostrDemoScreen.kt
@@ -2,10 +2,12 @@ package org.siamdev.zappos.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -20,7 +22,6 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.siamdev.zappos.keys.NIP44VERSION
 import org.siamdev.zappos.keys.NostrKeys
-import org.siamdev.zappos.keys.NostrPublicKey
 import org.siamdev.zappos.keys.NostrSigner
 
 data class NostrCardData(val title: String, val content: String)
@@ -44,7 +45,7 @@ fun NostrDemoScreen() {
     val sharedKey = NostrKeys.getSharedKey(secretKey, publicKey)
     val sharedSecretKey = sharedKey.secretKey().toHex()
     val sharedPublicKey = sharedKey.publicKey().toHex()
-    
+
     val ciphertext = NostrKeys.NIP04Encrypt(secretKey, publicKey, "Hello, NIP-04!")
     val plaintext = NostrKeys.NIP04Decrypt(secretKey, publicKey, ciphertext)
 
@@ -94,12 +95,13 @@ fun NostrCard(
 ) {
     Card(
         modifier = Modifier
-            .padding(vertical = 4.dp, horizontal = 0.dp),
+            .padding(vertical = 4.dp, horizontal = 0.dp)
+            .widthIn(min = 370.dp),
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         colors = CardDefaults.cardColors(containerColor = Color(0xFFF7F7F7))
     ) {
-        androidx.compose.foundation.layout.Column(
+        Column(
             modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {

--- a/composeApp/src/commonMain/kotlin/org/siamdev/zappos/screen/NostrDemoScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/siamdev/zappos/screen/NostrDemoScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.siamdev.zappos.keys.NIP44VERSION
 import org.siamdev.zappos.keys.NostrKeys
 import org.siamdev.zappos.keys.NostrPublicKey
 import org.siamdev.zappos.keys.NostrSigner
@@ -40,6 +41,15 @@ fun NostrDemoScreen() {
 
     val signerPublicKey = NostrSigner.keys(keys).getPublicKey()
 
+    val sharedKey = NostrKeys.getSharedKey(secretKey, publicKey)
+    val sharedSecretKey = sharedKey.secretKey().toHex()
+    val sharedPublicKey = sharedKey.publicKey().toHex()
+    
+    val ciphertext = NostrKeys.NIP04Encrypt(secretKey, publicKey, "Hello, NIP-04!")
+    val plaintext = NostrKeys.NIP04Decrypt(secretKey, publicKey, ciphertext)
+
+    val ciphertextChaCha20 = NostrKeys.NIP44Encrypt(secretKey, publicKey, "Hello, NIP-44!", NIP44VERSION.V2)
+    val plaintextChaCha20 = NostrKeys.NIP44Decrypt(secretKey, publicKey, ciphertextChaCha20)
 
     val cardList = listOf(
         NostrCardData("Private Key (hex)", secretKey.toHex()),
@@ -50,7 +60,13 @@ fun NostrDemoScreen() {
         NostrCardData("Nostr Signer", signerPublicKey.toHex()),
         NostrCardData("Parsed from nsec to hex", parsedSecretKey.toHex()),
         NostrCardData("Parsed from nsec to hex", parsedPublicKey.toHex()),
-        NostrCardData("Profile URI", npubUri)
+        NostrCardData("Profile URI", npubUri),
+        NostrCardData("Shared Secret Key", sharedSecretKey),
+        NostrCardData("Shared Public Key", sharedPublicKey),
+        NostrCardData("NIP 04 Encrypted Message", ciphertext),
+        NostrCardData("NIP 04 Decrypted Message", plaintext),
+        NostrCardData("NIP 44 Encrypted Message", ciphertextChaCha20),
+        NostrCardData("NIP 44 Decrypted Message", plaintextChaCha20)
     )
 
     LazyColumn(


### PR DESCRIPTION
# Feat: Shared Key & NIP Encryption for NostrKeys

## Summary of changes

- Added `getSharedKey` method for generating a shared secret between a secret key and a public key.
- Added `fromBytes` factory method for creating `NostrSecretKey` from a ByteArray.
- Added NIP-04 and NIP-44 encryption/decryption methods: `NIP04Encrypt`, `NIP04Decrypt`, `NIP44Encrypt`, `NIP44Decrypt`.
- Introduced `NIP44VERSION` enum for specifying NIP-44 version.
- Updated the NostrDemoScreen UI to showcase shared key and encryption/decryption demo usage.